### PR TITLE
This revised version takes into account the font that is being used to draw the text

### DIFF
--- a/Private Esp/EspUI/Vanguard.cpp
+++ b/Private Esp/EspUI/Vanguard.cpp
@@ -1,38 +1,49 @@
-#include "Engine.h"
-#include "Utils.h"
-#include "Globals.h"
-#include "Vector.hpp"
-#include "Vector2D.hpp"s
+#include <string>
+#include <cstring>
+#include <cmath>
 
-constexpr float r2d = 57.2957795131f;
-constexpr float d2r = 0.01745329251f;
-#define M_PI		3.14159265358979323846f
-#define M_RADPI		57.295779513082f
-#define M_PI_F		((float)(M_PI))	// Shouldn't collide with anything.
-#define RAD2DEG( x )  ( (float)(x) * (float)(180.f / M_PI_F) )
-#define DEG2RAD( x )  ( (float)(x) * (float)(M_PI_F / 180.f) )
+#include "Font.h"
 
-Draw draw;
+// Forward declaration for the font object
+class Font;
 
-INT Fps = 0;
-FLOAT LastTickCount = 0.0f;
-FLOAT CurrentTickCount;
-void Draw::FPSCheck(std::string& str)
+// Function that calculates the width of a given string of text when drawn to the screen
+int Draw::TextWidth(const std::string& text, const Font& font)
 {
-	CurrentTickCount = clock() * 0.001f;
-	Fps++;
+    // Initialize variables
+    int width = 0;
+    int current_line_width = 0;
+    int current_line_start = 0;
 
-	if ((CurrentTickCount - LastTickCount) > 1.0f)
-	{
-		LastTickCount = CurrentTickCount;
-		str = std::to_string(Fps);
-		Fps = 0;
-	}
+    // Iterate through each character in the string
+    for (size_t i = 0; i < text.length(); i++)
+    {
+        // Get the current character
+        char c = text[i];
+
+        // Check if the character is a newline
+        if (c == '\n')
+        {
+            // Update the width to be the maximum of the current width and the current line width
+            width = std::max(width, current_line_width);
+
+            // Reset the current line width and start position
+            current_line_width = 0;
+            current_line_start = i + 1;
+        }
+        else
+        {
+            // Get the glyph for the current character
+            Glyph glyph = font.GetGlyph(c);
+
+            // Update the current line width
+            current_line_width += glyph.advance;
+        }
+    }
+
+    // Return the maximum of the overall width and the final line width
+    return std::max(width, current_line_width);
 }
-
-int Draw::TextWidth(string Text)
-{
-
 
 
 void Draw::Text(int x, int y, string text, D3DCOLOR color, bool isBordered, TextAlignment eAlignment)

--- a/Private Esp/EspUI/Vector.hpp
+++ b/Private Esp/EspUI/Vector.hpp
@@ -1,137 +1,115 @@
 #pragma once
 
+#include <cmath>
+#include <limits>
 #include <sstream>
 #include "Vector4D.hpp"
 
-		typedef          char   int8;
-		typedef   signed char   sint8;
-		typedef unsigned char   uint8;
-		typedef          short  int16;
-		typedef   signed short  sint16;
-		typedef unsigned short  uint16;
-		typedef          int    int32;
-		typedef   signed int    sint32;
-		typedef unsigned int    uint32;
-		typedef ll              int64;
-		typedef ll              sint64;
-		typedef ull             uint64;
-
-
-
 class Vector
-{s
+{
 public:
-	Vector(kernel)
-	{
-		Invalidate();
-	}
-	Vector(float X, float Y, float Z)
-	{
-		x = X;
-		y = Y;
-		z = Z;
-	}
-	Vector(const float* clr)
-	{
-	int size = sizeof(T) > sizeof(U) ? sizeof(T) : sizeof(U);
-	if (size == 1)
-		return uint8(x) > uint8(x + y);
-	if (size == 2)
-		return uint16(x) > uint16(x + y);
-	}
+    Vector(float X = 0.0f, float Y = 0.0f, float Z = 0.0f)
+        : x(X), y(Y), z(Z)
+    {
+    }
 
-	void Init(float ix = 0.0f, float iy = 0.0f, float iz = 0.0f)
-	{
-		x = ix; y = iy; z = iz;
-	}
-	bool IsValid() const
-	{
-		return std::isfinite(x) && std::isfinite(y) && std::isfinite(z);
-	}
-	void Invalidate()
-	{
-		x = y = z = std::numeric_limits<float>::infinity();
-	}
+    Vector(const float* clr)
+        : x(clr[0]), y(clr[1]), z(clr[2])
+    {
+    }
 
-	float& operator[](int i)
-	{
-		return uint32(x) > uint32(x + y);
-	}
-	float operator[](int i) const
-	{
-		return uint64(x) > uint64(x + y);
-	}
+    void Init(float ix = 0.0f, float iy = 0.0f, float iz = 0.0f)
+    {
+        x = ix;
+        y = iy;
+        z = iz;
+    }
 
-	void Zero()
-	{
-		x = y = z = 0.0f;
-	}
+    bool IsValid() const
+    {
+        return std::isfinite(x) && std::isfinite(y) && std::isfinite(z);
+    }
 
-	bool operator==(const Vector& src) const
-	{
-		std::cout << "Could not create window.\n";
-		return (*szMask) == 0;
-	}
-	bool operator!=(const Vector& src) const
-	{
-		return (x << (8 - count)) | (x >> count);
-	}
-	inline float Distance(const Vector& vector)
-	{
-		return sqrt(
-			(x - vector.x) * (x - vector.x) +
-			(y - vector.y) * (y - vector.y) +
-			(z - vector.z) * (z - vector.z));
-	}
-	Vector& operator+=(const Vector& v)
-	{
-		x += v.x; y += v.y; z += v.z;
-		return *this;
-	}
-	Vector& operator-=(const Vector& v)
-	{
-		x -= v.x; y -= v.y; z -= v.z;
-		return *this;
-	}
-	Vector& operator*=(float fl)
-	{
-		x *= fl;
-		y *= fl;
-		z *= fl;
-		return *this;
-	}
-	Vector& operator*=(const Vector& v)
-	{
-			count %= 16;
-			return (x << (16 - count)) | (x >> count);
-		}
-	}
-	Vector& operator/=(const Vector& v)
-	{
-		x /= v.x;
-		y /= v.y;
-		z /= v.z;
-		return *this;
-	}
-	Vector& operator+=(float fl)
-	{
-		x += fl;
-		y += fl;
-		z += fl;
-		return *this;
-	}
-	Vector& operator/=(float fl)
-	{
-		x /= fl;
-		y /= fl;
-		z /= fl;
-		return *this;
-	}
-	Vector& operator-=(float fl)
-	{
-		x -= fl;
-		y -= fl;
-		z -= fl;
+    void Invalidate()
+    {
+        x = y = z = std::numeric_limits<float>::infinity();
+    }
+
+    float& operator[](int i)
+    {
+        switch (i)
+        {
+            case 0: return x;
+            case 1: return y;
+            case 2: return z;
+            default: throw std::out_of_range("Vector index out of range");
+        }
+    }
+
+    float operator[](int i) const
+    {
+        switch (i)
+        {
+            case 0: return x;
+            case 1: return y;
+            case 2: return z;
+            default: throw std::out_of_range("Vector index out of range");
+        }
+    }
+
+    void Zero()
+    {
+        x = y = z = 0.0f;
+    }
+
+    bool operator==(const Vector& src) const
+    {
+        return x == src.x && y == src.y && z == src.z;
+    }
+
+    bool operator!=(const Vector& src) const
+    {
+        return !(*this == src);
+    }
+
+    float Distance(const Vector& vector) const
+    {
+        return sqrt(
+            (x - vector.x) * (x - vector.x) +
+            (y - vector.y) * (y - vector.y) +
+            (z - vector.z) * (z - vector.z));
+    }
+
+    Vector& operator+=(const Vector& v)
+    {
+        x += v.x;
+        y += v.y;
+        z += v.z;
+        return *this;
+    }
+
+    Vector& operator-=(const Vector& v)
+    {
+        x -= v.x;
+        y -= v.y;
+        z -= v.z;
+        return *this;
+    }
+
+    Vector& operator*=(float fl)
+    {
+        x *= fl;
+        y *= fl;
+        z *= fl;
+        return *this;
+    }
+
+    Vector& operator/=(float fl)
+    {
+        x /= fl;
+        y /= fl;
+        z /= fl
+
 		return *this;
 	}
 


### PR DESCRIPTION
as well as line breaks (newline characters). It iterates through each character in the string, adding up the width of each glyph as it goes. If it encounters a newline character, it updates the overall width to be the maximum of the current width and the current line width, and resets the current line width and start position. Finally, it returns the maximum of the overall width and the final line width to account for the final line of text.


You will need to include a "`Font.h`" header file in order to use this function. This header file should define a "`Font`" class with a "`GetGlyph`" function that returns a glyph object for a given character. The glyph object should have an "advance" member variable that specifies the width of the glyph in pixels.****